### PR TITLE
[BUG] php 8.2 object type casting to int

### DIFF
--- a/src/Criteria/Expression/Traits.php
+++ b/src/Criteria/Expression/Traits.php
@@ -220,25 +220,13 @@ trait Traits
 			case 'boolean':
 			case \Aimeos\Base\DB\Statement\Base::PARAM_BOOL:
 				$value = (int) (bool) $value; break;
-            case 'int':
-            case 'integer':
-            case \Aimeos\Base\DB\Statement\Base::PARAM_INT:
-                $value = $value !== ''
-                    ? ( $value instanceof \Aimeos\MShop\Common\Item\Base
-                        ? (int) (string) $value
-                        : (int) $value
-                    )
-                    : 'null';
-                break;
-            case 'float':
-            case \Aimeos\Base\DB\Statement\Base::PARAM_FLOAT:
-                $value = $value !== ''
-                    ? ( $value instanceof \Aimeos\MShop\Common\Item\Base
-                        ? (double) (string) $value
-                        : (double) $value
-                    )
-                    : 'null';
-                break;
+			case 'int':
+			case 'integer':
+			case \Aimeos\Base\DB\Statement\Base::PARAM_INT:
+				$value = $value !== '' ? (int) (string) $value : 'null'; break; // objects must be casted to strings first
+			case 'float':
+			case \Aimeos\Base\DB\Statement\Base::PARAM_FLOAT:
+				$value = $value !== '' : (double) $value : 'null'; break;
 			case 'json':
 			case 'string':
 			case \Aimeos\Base\DB\Statement\Base::PARAM_STR:

--- a/src/Criteria/Expression/Traits.php
+++ b/src/Criteria/Expression/Traits.php
@@ -226,7 +226,7 @@ trait Traits
 				$value = $value !== '' ? (int) (string) $value : 'null'; break; // objects must be casted to strings first
 			case 'float':
 			case \Aimeos\Base\DB\Statement\Base::PARAM_FLOAT:
-				$value = $value !== '' : (double) $value : 'null'; break;
+				$value = $value !== '' ? (double) $value : 'null'; break;
 			case 'json':
 			case 'string':
 			case \Aimeos\Base\DB\Statement\Base::PARAM_STR:

--- a/src/Criteria/Expression/Traits.php
+++ b/src/Criteria/Expression/Traits.php
@@ -220,13 +220,25 @@ trait Traits
 			case 'boolean':
 			case \Aimeos\Base\DB\Statement\Base::PARAM_BOOL:
 				$value = (int) (bool) $value; break;
-			case 'int':
-			case 'integer':
-			case \Aimeos\Base\DB\Statement\Base::PARAM_INT:
-				$value = $value !== '' ? (int) $value : 'null'; break;
-			case 'float':
-			case \Aimeos\Base\DB\Statement\Base::PARAM_FLOAT:
-				$value = $value !== '' ? (double) $value : 'null'; break;
+            case 'int':
+            case 'integer':
+            case \Aimeos\Base\DB\Statement\Base::PARAM_INT:
+                $value = $value !== ''
+                    ? ( $value instanceof \Aimeos\MShop\Common\Item\Base
+                        ? (int) (string) $value
+                        : (int) $value
+                    )
+                    : 'null';
+                break;
+            case 'float':
+            case \Aimeos\Base\DB\Statement\Base::PARAM_FLOAT:
+                $value = $value !== ''
+                    ? ( $value instanceof \Aimeos\MShop\Common\Item\Base
+                        ? (double) (string) $value
+                        : (double) $value
+                    )
+                    : 'null';
+                break;
 			case 'json':
 			case 'string':
 			case \Aimeos\Base\DB\Statement\Base::PARAM_STR:


### PR DESCRIPTION
In php 8.2 casting object to int - does not work anymore (maybe related to [this](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.implicit-float-conversion))

Thus making all queries where Item object is passed in condition as value - to throw errors like
`Object of class Aimeos\MShop\Locale\Item\Site\Standard could not be converted to int`

Fix includes convering object to string before converting to int/float