### PR TITLE
Do not distribute development related files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.circleci export-ignore
+.gitattributes exprot-ignore
+.gitignore exprot-ignore
+.phpcs export-ignore
+build.xml export-ignore
+tests export-ignore


### PR DESCRIPTION
The composer package is distributed from GitHub via a git export. We therefore can prevent files from being distributed, by using `.gitattributes` file with `export-ignore`.

See: https://git-scm.com/docs/gitattributes#_export_ignore